### PR TITLE
Fix configure script to correctly retrieve cc path and flags.

### DIFF
--- a/configure
+++ b/configure
@@ -46,9 +46,9 @@ else
 fi
 
 # Find compiler
-CC=`${R_HOME}/bin/R CMD config CC`
-CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS`
-CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS`
+CC=`${R_HOME}/bin/R CMD config CC | grep -v WARNING`
+CFLAGS=`${R_HOME}/bin/R CMD config CFLAGS | grep -v WARNING`
+CPPFLAGS=`${R_HOME}/bin/R CMD config CPPFLAGS | grep -v WARNING`
 
 # For debugging
 echo "Using PKG_CFLAGS=$PKG_CFLAGS"


### PR DESCRIPTION
`R CMD` apparently outputs warnings such as "WARNING: ignoring environment value of R_HOME" to stdout, which ends up messing up configuration of the `CC`, `CFLAGS`, and `CPPFLAGS` environment variables.

This change allowed me to build the package under FreeBSD after setting `R_HOME` (I have another change in a different branch that bypasses `R_HOME` altogether, but that might not be desirable if there are multiple local R installs).