### PR TITLE
Default to SHA-256 hashes for public key fingerprints

### DIFF
--- a/R/list.R
+++ b/R/list.R
@@ -30,7 +30,7 @@ as.list.pubkey <- function(x, ...){
     type = type,
     size = size,
     ssh = paste(header, base64_encode(fp)),
-    fingerprint = md5(fp),
+    fingerprint = sha256(fp),
     data = data
   )
 }

--- a/tests/testthat/test_keys_dsa.R
+++ b/tests/testthat/test_keys_dsa.R
@@ -35,7 +35,7 @@ test_that("legacy pkcs1 format", {
 
 test_that("pubkey ssh fingerprint", {
   fp <- paste(as.list(pk1)$fingerprint, collapse = "")
-  expect_equal(fp, "6c42ea8454e549b855cadd7fc86609ca")
+  expect_equal(fp, "80e814f3f747a6427e2ab1c659ecbf3edcbeecc26039e7bcd207553619aec410")
   pk5 <- read_pubkey(readLines("../keys/authorized_keys")[1])
   expect_equal(pk1, pk5)
   pk6 <- read_pubkey(write_ssh(pk1))

--- a/tests/testthat/test_keys_ecdsa.R
+++ b/tests/testthat/test_keys_ecdsa.R
@@ -37,7 +37,7 @@ test_that("legacy pkcs1 format", {
 
 test_that("pubkey ssh fingerprint", {
   fp <- paste(as.list(pk1)$fingerprint, collapse = "")
-  expect_equal(fp, "100b0d5f53a36e63dc42085552cdc340")
+  expect_equal(fp, "53492762ee530db92cc0c651f4454803d474f3a5bef6cac301cc8f3aac5d7f9e")
   pk5 <- read_pubkey(readLines("../keys/authorized_keys")[3])
   expect_equal(pk1, pk5)
   pk6 <- read_pubkey(write_ssh(pk1))

--- a/tests/testthat/test_keys_ecdsa384.R
+++ b/tests/testthat/test_keys_ecdsa384.R
@@ -36,7 +36,7 @@ test_that("legacy pkcs1 format", {
 
 test_that("pubkey ssh fingerprint", {
   fp <- paste(as.list(pk1)$fingerprint, collapse = "")
-  expect_equal(fp, "8cf3736c4a28cf2bd63bbf3278d00630")
+  expect_equal(fp, "2378e98f946fbe07c28308835f932834a374a215ae515f65b77678613e412101")
 })
 
 test_that("signatures", {

--- a/tests/testthat/test_keys_ecdsa521.R
+++ b/tests/testthat/test_keys_ecdsa521.R
@@ -36,7 +36,7 @@ test_that("legacy pkcs1 format", {
 
 test_that("pubkey ssh fingerprint", {
   fp <- paste(as.list(pk1)$fingerprint, collapse = "")
-  expect_equal(fp, "904d4c50be879bf0557af96b9935f1c2")
+  expect_equal(fp, "7a67bb9829dd93cfa56bf116120ba6ef14e464f36d4dc07a97a71e63a0e70f6c")
 })
 
 test_that("signatures", {

--- a/tests/testthat/test_keys_ed25519.R
+++ b/tests/testthat/test_keys_ed25519.R
@@ -29,7 +29,7 @@ test_that("reading public key formats", {
 
 test_that("pubkey ssh fingerprint", {
   fp <- paste(as.list(pk1)$fingerprint, collapse = "")
-  expect_equal(fp, "2c9bea2e9a4ce1fb4438d854b27204b3")
+  expect_equal(fp, "e07a7f95a68c864c757942aac2a42ca3fb26f1f66cd37d6f77559b63847b9ade")
 })
 
 test_that("signatures", {

--- a/tests/testthat/test_keys_rsa.R
+++ b/tests/testthat/test_keys_rsa.R
@@ -37,7 +37,7 @@ test_that("legacy pkcs1 format", {
 
 test_that("pubkey ssh fingerprint", {
   fp <- paste(as.list(pk1)$fingerprint, collapse = "")
-  expect_equal(fp, "3ad46117a06192f13e55beb3cd4cfa6f")
+  expect_equal(fp, "d2cc4e49782bb98861990f7f3979cdcae7909b52ec08d5d8e223137a25705a27")
   pk7 <- read_pubkey(readLines("../keys/authorized_keys")[2])
   expect_equal(pk1, pk7)
   pk8 <- read_pubkey(write_ssh(pk1))


### PR DESCRIPTION
Currently public keys **cannot be generated** on FIPS-compliant systems because these systems do not permit use of the MD5 algorithm:

    > k <- openssl::rsa_keygen(2048)
    > pub <- k$pubkey
    Error: OpenSSL error in EVP_DigestInit_ex: disabled for fips

Given the existing API there's no easy way to pass through the hash function you want, so this commit does the easiest thing and just changes the fingerprint to use SHA-256, which will work on FIPS-compliant systems.

Worth mentioning is that recent versions of OpenSSL's command-line tools have also switched to SHA-256 by default, so this is not an unreasonable move.

Related unit tests have also been updated.

Side note: this originally surfaced in rstudio/rsconnect#452.