### PR TITLE
Windows: test with openssl-3

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,5 +1,5 @@
-VERSION = 1.1.1k
-PKG_CPPFLAGS = -I../windows/openssl-$(VERSION)/include
+VERSION = 3.0.1
+PKG_CPPFLAGS = -I../windows/openssl-$(VERSION)/include -DOPENSSL_SUPPRESS_DEPRECATED
 PKG_LIBS = -Lbcrypt -lstatbcrypt -L../windows/openssl-$(VERSION)/lib${R_ARCH}${CRT} \
 	-lssl -lcrypto -lws2_32 -lgdi32 -lcrypt32
 STATLIB = bcrypt/libstatbcrypt.a


### PR DESCRIPTION
This is just to test, for now I plan to stick with the LTS (long term support) branch of openssl, which currently is 1.1.1.