### PR TITLE
Allow passing a hash function to `as.list()` and `print()` for keys

### DIFF
--- a/R/list.R
+++ b/R/list.R
@@ -1,8 +1,8 @@
 #' @export
-as.list.key <- function(x, ...){
+as.list.key <- function(x, hashfun = md5, ...){
   key <- x
   pubkey <- derive_pubkey(key)
-  pk <- as.list(pubkey)
+  pk <- as.list(pubkey, hashfun = hashfun)
   list(
     type = pk$type,
     size = pk$size,
@@ -12,7 +12,7 @@ as.list.key <- function(x, ...){
 }
 
 #' @export
-as.list.pubkey <- function(x, ...){
+as.list.pubkey <- function(x, hashfun = md5, ...){
   pubkey <- x
   data <- decompose(pubkey)
   type <- ifelse(inherits(pubkey, "ed25519"), "ed25519", pubkey_type(pubkey))
@@ -30,7 +30,7 @@ as.list.pubkey <- function(x, ...){
     type = type,
     size = size,
     ssh = paste(header, base64_encode(fp)),
-    fingerprint = md5(fp),
+    fingerprint = hashfun(fp),
     data = data
   )
 }

--- a/R/read.R
+++ b/R/read.R
@@ -259,19 +259,19 @@ split_pem <- function(text) {
 }
 
 #' @export
-print.key <- function(x, ...){
+print.key <- function(x, hashfun = md5, ...){
   pk <- derive_pubkey(x)
-  fp <- fingerprint(pk)
+  fp <- fingerprint(pk, hashfun)
   cat(sprintf("[%d-bit %s private key]\n", pubkey_bitsize(pk), pubkey_type(pk)))
-  cat(sprintf("md5: %s\n", paste(fp, collapse = ":")))
+  print(fp)
 }
 
 #' @export
-print.pubkey <- function(x, ...){
-  fp <- fingerprint(x)
+print.pubkey <- function(x, hashfun = md5, ...){
+  fp <- fingerprint(x, hashfun)
   type <- class(x)[2]
   cat(sprintf("[%d-bit %s public key]\n", pubkey_bitsize(x), pubkey_type(x)))
-  cat(sprintf("md5: %s\n", paste(fp, collapse = ":")))
+  print(fp)
 }
 
 #' @export

--- a/tests/testthat/test_keys_dsa.R
+++ b/tests/testthat/test_keys_dsa.R
@@ -98,5 +98,15 @@ test_that("dsa_keygen works", {
   rm(key)
 })
 
+test_that("non-MD5 fingerprints work as expected", {
+  fp <- as.list(pk1, hashfun = sha256)$fingerprint
+  expect_s3_class(fp, "sha256")
+  expect_equal(
+    paste(fp, collapse = ""),
+    "80e814f3f747a6427e2ab1c659ecbf3edcbeecc26039e7bcd207553619aec410"
+  )
+  expect_silent(as.list(sk1, hashfun = sha256))
+})
+
 # Cleanup
 rm(sk1, pk1)

--- a/tests/testthat/test_keys_ecdsa.R
+++ b/tests/testthat/test_keys_ecdsa.R
@@ -95,6 +95,16 @@ test_that("ec_keygen works", {
   rm(key)
 })
 
+test_that("non-MD5 fingerprints work as expected", {
+  fp <- as.list(pk1, hashfun = sha256)$fingerprint
+  expect_s3_class(fp, "sha256")
+  expect_equal(
+    paste(fp, collapse = ""),
+    "53492762ee530db92cc0c651f4454803d474f3a5bef6cac301cc8f3aac5d7f9e"
+  )
+  expect_silent(as.list(sk1, hashfun = sha256))
+})
+
 # Cleanup
 rm(sk1, pk1)
 

--- a/tests/testthat/test_keys_ecdsa384.R
+++ b/tests/testthat/test_keys_ecdsa384.R
@@ -90,6 +90,16 @@ test_that("ec_keygen works", {
   rm(key)
 })
 
+test_that("non-MD5 fingerprints work as expected", {
+  fp <- as.list(pk1, hashfun = sha256)$fingerprint
+  expect_s3_class(fp, "sha256")
+  expect_equal(
+    paste(fp, collapse = ""),
+    "2378e98f946fbe07c28308835f932834a374a215ae515f65b77678613e412101"
+  )
+  expect_silent(as.list(sk1, hashfun = sha256))
+})
+
 # Cleanup
 rm(sk1, pk1)
 

--- a/tests/testthat/test_keys_ecdsa521.R
+++ b/tests/testthat/test_keys_ecdsa521.R
@@ -90,6 +90,16 @@ test_that("ec_keygen works", {
   rm(key)
 })
 
+test_that("non-MD5 fingerprints work as expected", {
+  fp <- as.list(pk1, hashfun = sha256)$fingerprint
+  expect_s3_class(fp, "sha256")
+  expect_equal(
+    paste(fp, collapse = ""),
+    "7a67bb9829dd93cfa56bf116120ba6ef14e464f36d4dc07a97a71e63a0e70f6c"
+  )
+  expect_silent(as.list(sk1, hashfun = sha256))
+})
+
 # Cleanup
 rm(sk1, pk1)
 

--- a/tests/testthat/test_keys_ed25519.R
+++ b/tests/testthat/test_keys_ed25519.R
@@ -78,6 +78,16 @@ test_that("ec_keygen works", {
   rm(key)
 })
 
+test_that("non-MD5 fingerprints work as expected", {
+  fp <- as.list(pk1, hashfun = sha256)$fingerprint
+  expect_s3_class(fp, "sha256")
+  expect_equal(
+    paste(fp, collapse = ""),
+    "e07a7f95a68c864c757942aac2a42ca3fb26f1f66cd37d6f77559b63847b9ade"
+  )
+  expect_silent(as.list(sk1, hashfun = sha256))
+})
+
 # Cleanup
 rm(sk1, pk1)
 


### PR DESCRIPTION
This aims to replace #93 with an approach that does not require any breaking changes.

Currently public keys **cannot be generated or even printed** on FIPS-compliant systems because these systems do not permit use of the MD5 algorithm:

    > k <- openssl::rsa_keygen(2048)
    > pub <- k$pubkey
    Error: OpenSSL error in EVP_DigestInit_ex: disabled for fips
    # Using another approach:
    > pub <- as.list(k)$pubkey
    Error: OpenSSL error in EVP_DigestInit_ex: disabled for fips
    # Not even printing will work, since it calls fingerprint(), too:
    > print(k)
    Error: OpenSSL error in EVP_DigestInit_ex: disabled for fips

This PR allows passing a new `hashfun` argument to the `as.list()` and `print()` methods for keys and public keys, which are in turn passed through to the underlying call to `fingerprint()`. This enables the following workarounds on FIPS systems:

    > pub <- as.list(k, hashfun = openssl::sha256)$pubkey
    > print(k, hashfun = openssl::sha256)
    [2048-bit rsa private key]
    sha256 20:c4:fc:84:44:5f:97:f4:2d:ef:15:db:b9:62:e6:e1:73:52:f9:c4:03:be:dd:f3:5c:5d:7f:8c:41:f9:ee:13

In order to preserve backwards compatibility, the hash function still defaults to MD5, but this could probably be changed in the future. Recent versions of OpenSSL's command-line tools, for example, have switched to SHA-256.

Some new unit tests have been added to test these features.

Side note: again, this originally surfaced in https://github.com/rstudio/rsconnect/issues/452.