### PR TITLE
Allow the test suite to run on a FIPS system

### DIFF
--- a/tests/testthat/test_keys_dsa.R
+++ b/tests/testthat/test_keys_dsa.R
@@ -5,6 +5,8 @@ sk1 <- read_key("../keys/id_dsa")
 pk1 <- read_pubkey("../keys/id_dsa.pub")
 
 test_that("reading protected keys", {
+  # These keys use MD5-hashed passwords, which is not permitted under FIPS-140.
+  skip_if(fips_mode())
   sk2 <- read_key("../keys/id_dsa.pw", password = "test")
   sk3 <- read_key("../keys/id_dsa.openssh")
   sk4 <- read_key("../keys/id_dsa.openssh.pw", password = "test")

--- a/tests/testthat/test_keys_ecdsa.R
+++ b/tests/testthat/test_keys_ecdsa.R
@@ -7,6 +7,8 @@ sk1 <- read_key("../keys/id_ecdsa")
 pk1 <- read_pubkey("../keys/id_ecdsa.pub")
 
 test_that("reading protected keys", {
+  # These keys use MD5-hashed passwords, which is not permitted under FIPS-140.
+  skip_if(fips_mode())
   sk2 <- read_key("../keys/id_ecdsa.pw", password = "test")
   sk3 <- read_key("../keys/id_ecdsa.openssh")
   sk4 <- read_key("../keys/id_ecdsa.openssh.pw", password = "test")

--- a/tests/testthat/test_keys_ecdsa384.R
+++ b/tests/testthat/test_keys_ecdsa384.R
@@ -7,6 +7,8 @@ sk1 <- read_key("../keys/id_ecdsa384")
 pk1 <- read_pubkey("../keys/id_ecdsa384.pub")
 
 test_that("reading protected keys", {
+  # These keys use MD5-hashed passwords, which is not permitted under FIPS-140.
+  skip_if(fips_mode())
   sk2 <- read_key("../keys/id_ecdsa384.pw", password = "test")
   sk3 <- read_key("../keys/id_ecdsa384.openssh")
   sk4 <- read_key("../keys/id_ecdsa384.openssh.pw", password = "test")

--- a/tests/testthat/test_keys_ecdsa521.R
+++ b/tests/testthat/test_keys_ecdsa521.R
@@ -7,6 +7,8 @@ sk1 <- read_key("../keys/id_ecdsa521")
 pk1 <- read_pubkey("../keys/id_ecdsa521.pub")
 
 test_that("reading protected keys", {
+  # These keys use MD5-hashed passwords, which is not permitted under FIPS-140.
+  skip_if(fips_mode())
   sk2 <- read_key("../keys/id_ecdsa521.pw", password = "test")
   sk3 <- read_key("../keys/id_ecdsa521.openssh")
   sk4 <- read_key("../keys/id_ecdsa521.openssh.pw", password = "test")

--- a/tests/testthat/test_keys_rsa.R
+++ b/tests/testthat/test_keys_rsa.R
@@ -5,6 +5,8 @@ sk1 <- read_key("../keys/id_rsa")
 pk1 <- read_pubkey("../keys/id_rsa.pub")
 
 test_that("reading protected keys", {
+  # These keys use MD5-hashed passwords, which is not permitted under FIPS-140.
+  skip_if(fips_mode())
   sk2 <- read_key("../keys/id_rsa.pw", password = "test")
   sk3 <- read_key("../keys/id_rsa.openssh")
   sk4 <- read_key("../keys/id_rsa.openssh.pw", password = "test")
@@ -45,11 +47,7 @@ test_that("pubkey ssh fingerprint", {
 })
 
 test_that("signatures", {
-  # MD5 signature
   msg <- readBin("../keys/message", raw(), 100)
-  sig <- readBin("../keys/message.sig.rsa.md5", raw(), 1000)
-  expect_equal(signature_create(msg, md5, sk1), sig)
-  expect_true(signature_verify(msg, sig, md5, pk1))
 
   # SHA1 signature
   sig <- readBin("../keys/message.sig.rsa.sha1", raw(), 1000)
@@ -60,6 +58,12 @@ test_that("signatures", {
   sig <- readBin("../keys/message.sig.rsa.sha256", raw(), 1000)
   expect_equal(signature_create(msg, sha256, sk1), sig)
   expect_true(signature_verify(msg, sig, sha256, pk1))
+
+  # MD5 signature
+  skip_if(fips_mode())
+  sig <- readBin("../keys/message.sig.rsa.md5", raw(), 1000)
+  expect_equal(signature_create(msg, md5, sk1), sig)
+  expect_true(signature_verify(msg, sig, md5, pk1))
 })
 
 test_that("roundtrip pem format", {

--- a/tests/testthat/test_pkcs.R
+++ b/tests/testthat/test_pkcs.R
@@ -1,6 +1,8 @@
 context("Test p12 / p7b format")
 
 test_that("reading p12 certificates", {
+  # These certs use ciphers not permitted under FIPS-140.
+  skip_if(fips_mode())
   p1 <- read_p12("../google.dk/wildcard-google.dk-chain.p12")
 
   expect_error(read_p12("../google.dk/wildcard-google.dk-chain-password.p12", password = ""), "password")
@@ -16,6 +18,7 @@ test_that("reading p12 certificates", {
 })
 
 test_that("reading p12 keys", {
+  skip_if(fips_mode())
   expect_error(read_p12("../certigo/example-root.p12", password = ""), "password")
   b1 <- read_p12("../certigo/example-root.p12", password = "password")
   c1 <- read_cert("../certigo/example-root.crt")
@@ -46,6 +49,7 @@ test_that("reading p12 keys", {
 })
 
 test_that("roundtrip p12 key and cert", {
+  skip_if(fips_mode())
   if(isTRUE(openssl_config()$ec)){
     b3 <- read_p12("../certigo/example-elliptic-sha1.p12", password = "password")
     c3 <- read_cert("../certigo/example-elliptic-sha1.crt")

--- a/tests/testthat/test_salting.R
+++ b/tests/testthat/test_salting.R
@@ -25,7 +25,7 @@ test_that("MD5 salts multiple values", {
 })
 
 test_that("RIPEMD160 salts single values", {
-  expect_false(ripemd160("foo") == md5("foo","bar"))
+  expect_false(ripemd160("foo") == ripemd160("foo","bar"))
 })
 
 test_that("RIPEMD160 salts multiple values", {
@@ -37,7 +37,7 @@ test_that("RIPEMD160 salts multiple values", {
 })
 
 test_that("SHA1 salts single values", {
-  expect_false(sha1("foo") == md5("foo","bar"))
+  expect_false(sha1("foo") == sha1("foo","bar"))
 })
 
 test_that("SHA1 salts multiple values", {
@@ -49,7 +49,7 @@ test_that("SHA1 salts multiple values", {
 })
 
 test_that("SHA256 salts single values", {
-  expect_false(sha256("foo") == md5("foo","bar"))
+  expect_false(sha256("foo") == sha256("foo","bar"))
 })
 
 test_that("SHA256 salts multiple values", {
@@ -61,7 +61,7 @@ test_that("SHA256 salts multiple values", {
 })
 
 test_that("SHA512 salts single values", {
-  expect_false(sha512("foo") == md5("foo","bar"))
+  expect_false(sha512("foo") == sha512("foo","bar"))
 })
 
 test_that("SHA512 salts multiple values", {

--- a/tests/testthat/test_salting.R
+++ b/tests/testthat/test_salting.R
@@ -1,10 +1,12 @@
 context("Test salting works with various algorithms")
 
 test_that("MD4 salts single values", {
+  skip_if(fips_mode())
   expect_false(md4("foo") == md4("foo","bar"))
 })
 
 test_that("MD4 salts multiple values", {
+  skip_if(fips_mode())
   salted_hashes <- md4(c("foo","bar"), "baz")
   unsalted_hashes <- md4(c("foo","bar"))
   expect_that(length(salted_hashes), equals(2))
@@ -13,10 +15,12 @@ test_that("MD4 salts multiple values", {
 })
 
 test_that("MD5 salts single values", {
+  skip_if(fips_mode())
   expect_false(md5("foo") == md5("foo","bar"))
 })
 
 test_that("MD5 salts multiple values", {
+  skip_if(fips_mode())
   salted_hashes <- md5(c("foo","bar"), "baz")
   unsalted_hashes <- md5(c("foo","bar"))
   expect_that(length(salted_hashes), equals(2))
@@ -25,10 +29,12 @@ test_that("MD5 salts multiple values", {
 })
 
 test_that("RIPEMD160 salts single values", {
+  skip_if(fips_mode())
   expect_false(ripemd160("foo") == ripemd160("foo","bar"))
 })
 
 test_that("RIPEMD160 salts multiple values", {
+  skip_if(fips_mode())
   salted_hashes <- ripemd160(c("foo","bar"), "baz")
   unsalted_hashes <- ripemd160(c("foo","bar"))
   expect_that(length(salted_hashes), equals(2))


### PR DESCRIPTION
This PR actually has two parts:

* Fixes the vectorised hash function tests, which all compare to MD5 -- this is probably a copy & paste error.
* Skip more tests that use non-approved algorithms.

With these changes the test suite runs on my test FIPS system, which is CentOS-based:

    Linking to: OpenSSL 1.0.2k-fips  26 Jan 2017 (FIPS)
    <snip>
    -- Skipped tests  -------------------------------------------------
    * curl cannot be loaded (1)
    * fips_mode() is TRUE (23)
    * openssl_config()$x25519 is not TRUE (2)

    [ FAIL 0 | WARN 0 | SKIP 26 | PASS 353 ]