### PR TITLE
Additional FIPS-related test changes

### DIFF
--- a/tests/testthat/test_fips.R
+++ b/tests/testthat/test_fips.R
@@ -1,0 +1,68 @@
+context("FIPS mode")
+
+test_that("printing works correctly under FIPS", {
+  skip_if(!fips_mode())
+  # Some print functions have a conditional check for fips_mode(). These tests
+  # verify that those branches produce working output on FIPS systems.
+  key <- openssl::rsa_keygen(2048L)
+  cert <- read_cert("../certigo/example-root.crt")
+  expect_output(print(key))
+  expect_output(print(key$pubkey))
+  expect_output(print(cert))
+})
+
+expect_md5_password <- function(file, password) {
+  expect_error(
+    read_key(file, password = password),
+    # The error message varies by OpenSSL-FIPS version.
+    "OpenSSL error in EVP_DigestInit_ex: disabled for (fips|FIPS)"
+  )
+}
+
+test_that("keys with MD5-hashed passwords generate errors under FIPS", {
+  skip_if(!fips_mode())
+  expect_md5_password("../keys/id_dsa.pw", password = "test")
+  if (openssl_config()$ec) {
+    expect_md5_password("../keys/id_ecdsa.pw", password = "test")
+    expect_md5_password("../keys/id_ecdsa384.pw", password = "test")
+    expect_md5_password("../keys/id_ecdsa521.pw", password = "test")
+  }
+})
+
+expect_unknown_cipher <- function(file, password = NULL) {
+  expect_error(
+    read_p12(file, password = password),
+    # The error message varies by OpenSSL-FIPS version.
+    "OpenSSL error in EVP_(PBE_CipherInit: unknown cipher|CipherInit_ex: disabled for FIPS)"
+  )
+}
+
+test_that("p12 certificates with unsupported ciphers generate errors under FIPS", {
+  skip_if(!fips_mode())
+  expect_unknown_cipher("../google.dk/wildcard-google.dk-chain.p12")
+  expect_unknown_cipher(
+      "../google.dk/wildcard-google.dk-chain-password.p12",
+      password = "password"
+  )
+  expect_unknown_cipher("../certigo/example-root.p12", password = "password")
+  expect_unknown_cipher("../certigo/example-leaf.p12", password = "password")
+  expect_unknown_cipher(
+    "../certigo/example-elliptic-sha1.p12", password = "password"
+  )
+})
+
+expect_invalid_key_size <- function(expr) {
+  # The error message varies by OpenSSL version and algorithm.
+  expect_error(expr, "(key size invalid|key too short|invalid key length|null)")
+}
+
+test_that("small keys cannot be generated under FIPS", {
+  skip_if(!fips_mode())
+  # Required on some Red Hat systems to actually enforce full key length
+  # requirements.
+  Sys.setenv("OPENSSL_ENFORCE_MODULUS_BITS" = "1")
+  expect_invalid_key_size(rsa_keygen(512))
+  expect_invalid_key_size(rsa_keygen(1024))
+  expect_invalid_key_size(dsa_keygen(512))
+  expect_invalid_key_size(dsa_keygen(1024))
+})

--- a/tests/testthat/test_keys_dsa.R
+++ b/tests/testthat/test_keys_dsa.R
@@ -5,17 +5,15 @@ sk1 <- read_key("../keys/id_dsa")
 pk1 <- read_pubkey("../keys/id_dsa.pub")
 
 test_that("reading protected keys", {
-  if(fips_mode()){
-    expect_error(read_key("../keys/id_dsa.pw", password = "test"), "FIPS")
-  } else {
-    expect_error(read_key("../keys/id_dsa.pw", password = ""), "bad")
-    sk2 <- read_key("../keys/id_dsa.pw", password = "test")
-    expect_equal(sk1, sk2)
-  }
-  sk3 <- read_key("../keys/id_dsa.openssh")
-  sk4 <- read_key("../keys/id_dsa.openssh.pw", password = "test")
-
+  expect_error(read_key("../keys/id_dsa.pw", password = ""))
+  sk2 <- read_key("../keys/id_dsa.openssh")
+  sk3 <- read_key("../keys/id_dsa.openssh.pw", password = "test")
+  expect_equal(sk1, sk2)
   expect_equal(sk1, sk3)
+
+  # This key uses a MD5-hashed password, which is not permitted under FIPS-140.
+  skip_if(fips_mode())
+  sk4 <- read_key("../keys/id_dsa.pw", password = "test")
   expect_equal(sk1, sk4)
 })
 
@@ -92,16 +90,15 @@ test_that("signature path interface", {
 })
 
 test_that("dsa_keygen works", {
-  if(!fips_mode()){
-    key <- dsa_keygen(1024)
-    expect_is(key, "dsa")
-    expect_equal(as.list(key)$size, 1024)
-    rm(key)
-  }
-
   key <- dsa_keygen(2048)
   expect_is(key, "dsa")
   expect_equal(as.list(key)$size, 2048)
+  rm(key)
+
+  skip_if(fips_mode())
+  key <- dsa_keygen(1024)
+  expect_is(key, "dsa")
+  expect_equal(as.list(key)$size, 1024)
   rm(key)
 })
 

--- a/tests/testthat/test_keys_ecdsa.R
+++ b/tests/testthat/test_keys_ecdsa.R
@@ -7,17 +7,15 @@ sk1 <- read_key("../keys/id_ecdsa")
 pk1 <- read_pubkey("../keys/id_ecdsa.pub")
 
 test_that("reading protected keys", {
-  if(fips_mode()){
-    expect_error(read_key("../keys/id_ecdsa.pw", password = "test"), "FIPS")
-  } else {
-    expect_error(read_key("../keys/id_ecdsa.pw", password = NULL), "bad")
-    sk2 <- read_key("../keys/id_ecdsa.pw", password = "test")
-    expect_equal(sk1, sk2)
-  }
-  sk3 <- read_key("../keys/id_ecdsa.openssh")
-  sk4 <- read_key("../keys/id_ecdsa.openssh.pw", password = "test")
-
+  expect_error(read_key("../keys/id_ecdsa.pw", password = ""))
+  sk2 <- read_key("../keys/id_ecdsa.openssh")
+  sk3 <- read_key("../keys/id_ecdsa.openssh.pw", password = "test")
+  expect_equal(sk1, sk2)
   expect_equal(sk1, sk3)
+
+  # This key uses a MD5-hashed password, which is not permitted under FIPS-140.
+  skip_if(fips_mode())
+  sk4 <- read_key("../keys/id_ecdsa.pw", password = "test")
   expect_equal(sk1, sk4)
 })
 

--- a/tests/testthat/test_keys_ecdsa384.R
+++ b/tests/testthat/test_keys_ecdsa384.R
@@ -7,16 +7,15 @@ sk1 <- read_key("../keys/id_ecdsa384")
 pk1 <- read_pubkey("../keys/id_ecdsa384.pub")
 
 test_that("reading protected keys", {
-  if(fips_mode()){
-    expect_error(read_key("../keys/id_ecdsa384.pw", password = "test"), "FIPS")
-  } else {
-    expect_error(read_key("../keys/id_ecdsa384.pw", password = NULL), "bad")
-    sk2 <- read_key("../keys/id_ecdsa384.pw", password = "test")
-    expect_equal(sk1, sk2)
-  }
-  sk3 <- read_key("../keys/id_ecdsa384.openssh")
-  sk4 <- read_key("../keys/id_ecdsa384.openssh.pw", password = "test")
+  expect_error(read_key("../keys/id_ecdsa384.pw", password = NULL))
+  sk2 <- read_key("../keys/id_ecdsa384.openssh")
+  sk3 <- read_key("../keys/id_ecdsa384.openssh.pw", password = "test")
+  expect_equal(sk1, sk2)
   expect_equal(sk1, sk3)
+
+  # This key uses a MD5-hashed password, which is not permitted under FIPS-140.
+  skip_if(fips_mode())
+  sk4 <- read_key("../keys/id_ecdsa384.pw", password = "test")
   expect_equal(sk1, sk4)
 })
 

--- a/tests/testthat/test_keys_ecdsa521.R
+++ b/tests/testthat/test_keys_ecdsa521.R
@@ -7,16 +7,15 @@ sk1 <- read_key("../keys/id_ecdsa521")
 pk1 <- read_pubkey("../keys/id_ecdsa521.pub")
 
 test_that("reading protected keys", {
-  if(fips_mode()){
-    expect_error(read_key("../keys/id_ecdsa521.pw", password = "test"), "FIPS")
-  } else {
-    expect_error(read_key("../keys/id_ecdsa521.pw", password = NULL), "bad")
-    sk2 <- read_key("../keys/id_ecdsa521.pw", password = "test")
-    expect_equal(sk1, sk2)
-  }
-  sk3 <- read_key("../keys/id_ecdsa521.openssh")
-  sk4 <- read_key("../keys/id_ecdsa521.openssh.pw", password = "test")
+  expect_error(read_key("../keys/id_ecdsa521.pw", password = NULL))
+  sk2 <- read_key("../keys/id_ecdsa521.openssh")
+  sk3 <- read_key("../keys/id_ecdsa521.openssh.pw", password = "test")
+  expect_equal(sk1, sk2)
   expect_equal(sk1, sk3)
+
+  # This key uses a MD5-hashed password, which is not permitted under FIPS-140.
+  skip_if(fips_mode())
+  sk4 <- read_key("../keys/id_ecdsa521.pw", password = "test")
   expect_equal(sk1, sk4)
 })
 

--- a/tests/testthat/test_keys_rsa.R
+++ b/tests/testthat/test_keys_rsa.R
@@ -5,17 +5,15 @@ sk1 <- read_key("../keys/id_rsa")
 pk1 <- read_pubkey("../keys/id_rsa.pub")
 
 test_that("reading protected keys", {
-  if(fips_mode()){
-    expect_error(read_key("../keys/id_rsa.pw", password = "test"), "FIPS")
-  } else {
-    expect_error(read_key("../keys/id_rsa.pw", password = ""), "bad")
-    sk2 <- read_key("../keys/id_rsa.pw", password = "test")
-    expect_equal(sk1, sk2)
-  }
-
-  sk3 <- read_key("../keys/id_rsa.openssh")
-  sk4 <- read_key("../keys/id_rsa.openssh.pw", password = "test")
+  expect_error(read_key("../keys/id_rsa.pw", password = ""))
+  sk2 <- read_key("../keys/id_rsa.openssh")
+  sk3 <- read_key("../keys/id_rsa.openssh.pw", password = "test")
+  expect_equal(sk1, sk2)
   expect_equal(sk1, sk3)
+
+  # This key uses a MD5-hashed password, which is not permitted under FIPS-140.
+  skip_if(fips_mode())
+  sk4 <- read_key("../keys/id_rsa.pw", password = "test")
   expect_equal(sk1, sk4)
 })
 
@@ -90,14 +88,15 @@ test_that("signature path interface", {
 })
 
 test_that("rsa_keygen works", {
-  key <- rsa_keygen(1024)
-  expect_is(key, "rsa")
-  expect_equal(as.list(key)$size, 1024)
-  rm(key)
-
   key <- rsa_keygen(2048)
   expect_is(key, "rsa")
   expect_equal(as.list(key)$size, 2048)
+  rm(key)
+
+  skip_if(fips_mode())
+  key <- rsa_keygen(1024)
+  expect_is(key, "rsa")
+  expect_equal(as.list(key)$size, 1024)
   rm(key)
 })
 

--- a/tests/testthat/test_pkcs.R
+++ b/tests/testthat/test_pkcs.R
@@ -1,50 +1,59 @@
 context("Test p12 / p7b format")
 
 test_that("reading p12 certificates", {
-  skip_if(fips_mode())
-  p1 <- read_p12("../google.dk/wildcard-google.dk-chain.p12")
-
   expect_error(read_p12("../google.dk/wildcard-google.dk-chain-password.p12", password = ""), "password")
-  p2 <- read_p12("../google.dk/wildcard-google.dk-chain-password.p12", password = "password")
-  expect_identical(p1, p2)
 
   bundle <- read_cert_bundle("../google.dk/wildcard-google.dk-chain.pem")
-  expect_identical(p1$ca, bundle)
-
   leaf <- read_cert("../google.dk/wildcard-google.dk-leaf.crt", der = TRUE)
   expect_identical(leaf, bundle[[1]])
 
+  # These certs use ciphers not permitted under FIPS-140.
+  skip_if(fips_mode())
+
+  p1 <- read_p12("../google.dk/wildcard-google.dk-chain.p12")
+  expect_identical(p1$ca, bundle)
+
+  p2 <- read_p12("../google.dk/wildcard-google.dk-chain-password.p12", password = "password")
+  expect_identical(p1, p2)
 })
 
 test_that("reading p12 keys", {
-  skip_if(fips_mode())
   expect_error(read_p12("../certigo/example-root.p12", password = ""), "password")
-  b1 <- read_p12("../certigo/example-root.p12", password = "password")
+  expect_error(read_p12("../certigo/example-leaf.p12", password = ""), "password")
+
   c1 <- read_cert("../certigo/example-root.crt")
   p7 <- read_p7b("../certigo/example-root.p7b")
-  expect_identical(b1$cert, c1)
   expect_identical(c1, p7[[1]])
-  expect_identical(b1$cert$pubkey, b1$key$pubkey)
 
-  expect_error(read_p12("../certigo/example-leaf.p12", password = ""), "password")
-  b2<- read_p12("../certigo/example-leaf.p12", password = "password")
   c2 <- read_cert("../certigo/example-leaf.crt")
   p7 <- read_p7b("../certigo/example-leaf.p7b")
-  expect_identical(b2$cert, c2)
   expect_identical(c2, p7[[1]])
-  expect_identical(b2$cert$pubkey, b2$key$pubkey)
 
-  if(isTRUE(openssl_config()$ec)){
-    expect_error(read_p12("../certigo/example-elliptic-sha1.p12", password = ""), "password")
-    b3 <- read_p12("../certigo/example-elliptic-sha1.p12", password = "password")
-    c3 <- read_cert("../certigo/example-elliptic-sha1.crt")
-    p7 <- read_p7b("../certigo/example-elliptic-sha1.p7b")
-    k3 <- read_key("../certigo/example-elliptic-sha1.key")
-    expect_identical(b3$cert, c3)
-    expect_identical(c3, p7[[1]])
-    expect_identical(b3$key, k3)
-    expect_identical(b3$cert$pubkey, b3$key$pubkey)
-  }
+  skip_if(fips_mode())
+
+  b1 <- read_p12("../certigo/example-root.p12", password = "password")
+  expect_identical(b1$cert, c1)
+  expect_identical(b1$cert$pubkey, b1$key$pubkey)
+
+  b2 <- read_p12("../certigo/example-leaf.p12", password = "password")
+  expect_identical(b2$cert, c2)
+  expect_identical(b2$cert$pubkey, b2$key$pubkey)
+})
+
+test_that("reading p12 keys with elliptic curves", {
+  skip_if(!openssl_config()$ec)
+  expect_error(read_p12("../certigo/example-elliptic-sha1.p12", password = ""), "password")
+
+  c3 <- read_cert("../certigo/example-elliptic-sha1.crt")
+  p7 <- read_p7b("../certigo/example-elliptic-sha1.p7b")
+  k3 <- read_key("../certigo/example-elliptic-sha1.key")
+  expect_identical(c3, p7[[1]])
+
+  skip_if(fips_mode())
+  b3 <- read_p12("../certigo/example-elliptic-sha1.p12", password = "password")
+  expect_identical(b3$cert, c3)
+  expect_identical(b3$key, k3)
+  expect_identical(b3$cert$pubkey, b3$key$pubkey)
 })
 
 test_that("roundtrip p12 key and cert", {


### PR DESCRIPTION
This PR does the following:

* Adds a suite of tests specifically for FIPS. This systematically pulls various cases that are skipped and tests that they generate the right error messages. It also tests the `print()` related changes.

* Reorder the cert and key tests to skip as little as possible.

After this I see the following on CentOS7:

```
Linking to: OpenSSL 1.0.2k-fips  26 Jan 2017 (FIPS)
<snip>
-- Skipped tests  -------------------------------------------------
* fips_mode() is TRUE (34)
* packageVersion("curl") < "4.3.3" is TRUE (1)

[ FAIL 0 | WARN 0 | SKIP 35 | PASS 375 ]
```

And on RHEL8 (really, Rocky 8):

```
Linking to: OpenSSL 1.1.1k  FIPS 25 Mar 2021 (FIPS)
<snip>
-- Skipped tests  -------------------------------------------------
* fips_mode() is TRUE (37)
* packageVersion("curl") < "4.3.3" is TRUE (1)

[ FAIL 0 | WARN 0 | SKIP 38 | PASS 392 ]
```