### PR TITLE
Improve detection of `fips_mode()` on OpenSSL version 3

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -7,6 +7,10 @@
 #define HAS_ECX
 #endif
 
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+#include <openssl/provider.h>
+#endif
+
 SEXP R_openssl_config() {
   int has_ec = 1;
   #ifdef OPENSSL_NO_EC
@@ -34,6 +38,10 @@ SEXP R_openssl_fips_mode(){
   int enabled = FIPS_mode();
 #else
   int enabled = EVP_default_properties_is_fips_enabled(NULL);
+  if (!enabled) {
+    enabled = OSSL_PROVIDER_available(NULL, "fips") &&
+      !OSSL_PROVIDER_available(NULL, "default");
+  }
 #endif
   return Rf_ScalarLogical(enabled);
 }


### PR DESCRIPTION
It's possible to be in FIPS mode [in two ways](https://www.openssl.org/docs/man3.0/man7/fips_module.html) on version 3:

1. Have non-FIPS providers loaded but algorithm selection limited to those with a `"fips=yes"` property. This is what we currently check for with `EVP_default_properties_is_fips_enabled()`.

2. Have only the FIPS provider loaded to begin with. When this is true, there is no need to limit algorithm selection by property, because only FIPS approved algorithms are available to begin with.

This PR expands the existing check to include scenario (2).

Tested on Fedora 36 with OpenSSL 3.