### PR TITLE
tests: expected message for read_key() without password

### DIFF
--- a/tests/testthat/test_keys_ed25519.R
+++ b/tests/testthat/test_keys_ed25519.R
@@ -13,7 +13,7 @@ test_that("reading protected keys", {
   expect_equal(sk1, sk2)
   expect_equal(sk1, sk3)
   expect_equal(sk1, sk4)
-  expect_error(read_key("../keys/id_ed25519.pw", password = NULL), "bad")
+  expect_error(read_key("../keys/id_ed25519.pw", password = NULL), "bad|empty")
 })
 
 test_that("reading public key formats", {


### PR DESCRIPTION
With OpenSSL 3.0.2 read_key() with a NULL password will create an
error message like

    OpenSSL error: 408CA279B07F0000:error:11800074:PKCS12
    routines:PKCS12_pbe_crypt_ex:pkcs12 cipherfinal
    error:../crypto/pkcs12/p12_decr.c:86:empty password\nk.c:124:\n"

which does not contain the word "bad". Adjust the test to look for
"password" instead.

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>