### PR TITLE
Disable bcrypt_pbkdf() if FIPS mode is enforced

### DIFF
--- a/R/bcrypt.R
+++ b/R/bcrypt.R
@@ -12,6 +12,8 @@
 #' @param rounds number of hashing rounds
 #' @param size desired length of the output key
 bcrypt_pbkdf <- function(password, salt, rounds = 16L, size = 32L){
+  if(fips_mode())
+    stop("Disabled for FIPS")
   if(is.character(password))
     password <- charToRaw(password)
   stopifnot(is.raw(password))


### PR DESCRIPTION
This PR introduces a change that prevents usage of `bcrypt_pbkdf()` when `fips_mode()` is enabled. 
Also see #112