### PR TITLE
add sodium check

### DIFF
--- a/tests/testthat/test_sodium.R
+++ b/tests/testthat/test_sodium.R
@@ -1,6 +1,7 @@
 context("Sodium Compatibility")
 
 test_that("Signatures are compatible with sodium", {
+  skip_if_not_installed('sodium')
   skip_if(fips_mode())
   skip_if_not(openssl_config()$x25519)
 
@@ -26,6 +27,7 @@ test_that("Signatures are compatible with sodium", {
 })
 
 test_that("Diffie Hellman is compatible with sodium", {
+  skip_if_not_installed('sodium')
   skip_if(fips_mode())
   skip_if_not(openssl_config()$x25519)
   # Generate keypair with sodium


### PR DESCRIPTION
The `test_sodium.R` tests assume `sodium` is installed, but it is listed as "Suggests". This adds a skip condition to check.