### PR TITLE
Added support for OAEP padding to RSA encryption/decryption.

### DIFF
--- a/R/rsa.R
+++ b/R/rsa.R
@@ -8,6 +8,7 @@
 #'
 #' @export
 #' @param data raw vector of max 245 bytes (for 2048 bit keys) with data to encrypt/decrypt
+#' @param oaep if TRUE, changes padding to EME-OAEP as defined in PKCS #1 v2.0
 #' @inheritParams signature_create
 #' @rdname rsa_encrypt
 #' @aliases rsa encrypt
@@ -28,19 +29,19 @@
 #' tempkey <- rsa_decrypt(ciphertext, key)
 #' message <- aes_cbc_decrypt(blob, tempkey, iv)
 #' out <- rawToChar(message)
-rsa_encrypt <- function(data, pubkey = my_pubkey()){
+rsa_encrypt <- function(data, pubkey = my_pubkey(), oaep = FALSE){
   pk <- read_pubkey(pubkey)
   stopifnot(inherits(pk, "rsa"))
   stopifnot(is.raw(data))
-  .Call(R_rsa_encrypt, data, pk)
+  .Call(R_rsa_encrypt, data, pk, oaep)
 }
 
 #' @useDynLib openssl R_rsa_decrypt
 #' @export
 #' @rdname rsa_encrypt
-rsa_decrypt <- function(data, key = my_key(), password = askpass){
+rsa_decrypt <- function(data, key = my_key(), password = askpass, oaep = FALSE){
   sk <- read_key(key, password)
   stopifnot(inherits(sk, "rsa"))
   stopifnot(is.raw(data))
-  .Call(R_rsa_decrypt, data, sk)
+  .Call(R_rsa_decrypt, data, sk, oaep)
 }

--- a/man/rsa_encrypt.Rd
+++ b/man/rsa_encrypt.Rd
@@ -7,14 +7,16 @@
 \alias{rsa_decrypt}
 \title{Low-level RSA encryption}
 \usage{
-rsa_encrypt(data, pubkey = my_pubkey())
+rsa_encrypt(data, pubkey = my_pubkey(), oaep = FALSE)
 
-rsa_decrypt(data, key = my_key(), password = askpass)
+rsa_decrypt(data, key = my_key(), password = askpass, oaep = FALSE)
 }
 \arguments{
 \item{data}{raw vector of max 245 bytes (for 2048 bit keys) with data to encrypt/decrypt}
 
 \item{pubkey}{public key or file path. See \code{\link[=read_pubkey]{read_pubkey()}}.}
+
+\item{oaep}{if TRUE, changes padding to EME-OAEP as defined in PKCS #1 v2.0}
 
 \item{key}{private key or file path. See \code{\link[=read_key]{read_key()}}.}
 

--- a/src/rsa.c
+++ b/src/rsa.c
@@ -5,13 +5,14 @@
 #include <openssl/pem.h>
 #include "utils.h"
 
-SEXP R_rsa_encrypt(SEXP data, SEXP keydata) {
+SEXP R_rsa_encrypt(SEXP data, SEXP keydata, SEXP oaep) {
   const unsigned char *ptr = RAW(keydata);
   RSA *rsa = d2i_RSA_PUBKEY(NULL, &ptr, LENGTH(keydata));
+  int pad = asLogical(oaep) ? RSA_PKCS1_OAEP_PADDING : RSA_PKCS1_PADDING;
   bail(!!rsa);
   int keysize = RSA_size(rsa);
   unsigned char* buf = OPENSSL_malloc(keysize);
-  int len = RSA_public_encrypt(LENGTH(data), RAW(data), buf, rsa, RSA_PKCS1_PADDING);
+  int len = RSA_public_encrypt(LENGTH(data), RAW(data), buf, rsa, pad);
   bail(len > 0);
   RSA_free(rsa);
   SEXP res = allocVector(RAWSXP, len);
@@ -20,13 +21,14 @@ SEXP R_rsa_encrypt(SEXP data, SEXP keydata) {
   return res;
 }
 
-SEXP R_rsa_decrypt(SEXP data, SEXP keydata){
+SEXP R_rsa_decrypt(SEXP data, SEXP keydata, SEXP oaep){
   const unsigned char *ptr = RAW(keydata);
   RSA *rsa = d2i_RSAPrivateKey(NULL, &ptr, LENGTH(keydata));
+  int pad = asLogical(oaep) ? RSA_PKCS1_OAEP_PADDING : RSA_PKCS1_PADDING;
   bail(!!rsa);
   int keysize = RSA_size(rsa);
   unsigned char* buf = OPENSSL_malloc(keysize);
-  int len = RSA_private_decrypt(LENGTH(data), RAW(data), buf, rsa, RSA_PKCS1_PADDING);
+  int len = RSA_private_decrypt(LENGTH(data), RAW(data), buf, rsa, pad);
   bail(len > 0);
   RSA_free(rsa);
   SEXP res = allocVector(RAWSXP, len);


### PR DESCRIPTION
I added support for [OAEP padding](https://www.openssl.org/docs/man3.1/man3/RSA_public_encrypt.html) which partially addresses #65. I added an `oaep` logical argument to `rsa_encrypt` and `rsa_decrypt` and made the necessary changes to the C code. I am by no means proficient in C... However, I tested the package, checked that `rsa_encrypt` and `rsa_decrypt` worked for a simple example using the OAEP option and used it successfully to pass credentials to an api I use that requires this option. Everything seems to work fine.