### PR TITLE
fix: add missing include to compatibility.h

### DIFF
--- a/src/compatibility.h
+++ b/src/compatibility.h
@@ -1,5 +1,6 @@
 /* Compatibility stuff for API changes in OpenSSL 1.1 */
 #include <openssl/opensslv.h>
+#include <openssl/x509.h>
 #if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL
 #define HAS_OPENSSL11_API 1
 #elif !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100001L


### PR DESCRIPTION
System Info:
- OS: RHEL 7
- OpenSSL version: 1.0.2k
- GCC version: 10.1.0
- R version: 4.4.1
- R-openssl version: master branch ([commit](https://github.com/jeroen/openssl/commit/62e3e9546cdd872187def36fb1cbfb70633caf9c))

Was getting a compilation error due to "unknown type X509" while compiling on a legacy system with openssl-1.0.2k. Fixed by adding missing header in "compatibility.h".

[log.txt](https://github.com/user-attachments/files/22318402/log.txt)
