### PR TITLE
Correct free()-ing of objects

### DIFF
--- a/src/pem.c
+++ b/src/pem.c
@@ -32,6 +32,9 @@ SEXP R_parse_pem(SEXP input){
   }
   UNPROTECT(1);
   BIO_free(mem);
+  if(name) OPENSSL_free(name);
+  if(header) OPENSSL_free(header);
+  if(data) OPENSSL_free(data);
   ERR_clear_error();
   return out;
 }

--- a/src/signing.c
+++ b/src/signing.c
@@ -91,6 +91,7 @@ SEXP R_parse_ecdsa(SEXP buf){
   SET_VECTOR_ELT(out, 0, bignum2r(r));
   SET_VECTOR_ELT(out, 1, bignum2r(s));
   UNPROTECT(1);
+  ECDSA_SIG_free(sig);
   return out;
 }
 
@@ -102,7 +103,7 @@ SEXP R_write_ecdsa(SEXP r, SEXP s){
   bail(siglen > 0);
   SEXP res = Rf_allocVector(RAWSXP, siglen);
   memcpy(RAW(res), buf, siglen);
-  free(buf);
+  OPENSSL_free(buf);
   ECDSA_SIG_free(sig);
   return res;
 }

--- a/tests/testthat/test_keys_ecdsa.R
+++ b/tests/testthat/test_keys_ecdsa.R
@@ -102,6 +102,15 @@ test_that("ec_keygen works", {
   rm(key)
 })
 
+test_that("ecdsa_write works", {
+  msg <- readBin("../keys/message", raw(), 100)
+  key <- ec_keygen()
+  sig <- signature_create(msg, sha256, key)
+  params <- ecdsa_parse(sig)
+  out <- ecdsa_write(params$r, params$s)
+  expect_identical(sig, out)
+})
+  
 # Cleanup
 rm(sk1, pk1)
 


### PR DESCRIPTION
This example started failing after a [recent](https://github.com/google/tcmalloc/commit/44fa583753efd80f75a2d335f859b227c3d618e3) hardening of some low-level library code internally:

https://github.com/jeroen/openssl/blob/2cef3a69d9c15e1160896573b596c366f68ee64f/man/signatures.Rd#L78

```
tcmalloc/error_reporting.cc:185 CHECK in ReportCorruptedFree: Attempted to free corrupted pointer 0x72f23fe19368.  Expected alignment 32
```

Gemini identified these as fixes, which do work and pass my smell test.

I found this as an example on GitHub of another library using `OPENSSL_free()` on the `pp` passed to `i2d_ECDSA_SIG()`:

https://github.com/winscp/winscp/blob/924564cc6bafe5e0a3c47f9937eab41ae2294605/libs/openssl/crypto/sm2/sm2_sign.c#L536